### PR TITLE
ignore quora truncated text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ venv/
 .pytest_cache/
 *.egg
 .idea/
+.vscode
 
 *.mobi
 *.epub

--- a/getbook/core/config.py
+++ b/getbook/core/config.py
@@ -44,7 +44,10 @@ ignored_symbols = (
     'instapaper_ignore',
     'languages',
     'toc',
+    'ui_qtext_truncated',
+    'ui_qtext_truncated_text',
 )
+
 ignored_prefix_symbols = (
     'ad-',
     'ad_',


### PR DESCRIPTION
Thanks for the hard work in this library! I am a big fan! It helps me a lot. I have a problem,

for example, like this quora site, 

https://www.quora.com/What-are-some-spooky-psychological-facts

![Image](https://user-images.githubusercontent.com/5022872/70338956-d405f300-1888-11ea-8342-139ea8124d9e.jpeg)

![Image 2](https://user-images.githubusercontent.com/5022872/70338959-d5cfb680-1888-11ea-82d6-de99cfd9286e.jpeg)

Look, the text is repeated. 

quora's answer show the truncated text, and then expanded text, so the text repeated. Like: 

<img width="832" alt="Screen Shot 2019-12-07 at 12 29 01 AM" src="https://user-images.githubusercontent.com/5022872/70339117-352dc680-1889-11ea-8d97-8872ab329453.png">

<img width="627" alt="Screen Shot 2019-12-07 at 12 30 02 AM" src="https://user-images.githubusercontent.com/5022872/70339127-3c54d480-1889-11ea-868a-00024a8e423d.png">


<img width="616" alt="Screen Shot 2019-12-07 at 12 29 39 AM" src="https://user-images.githubusercontent.com/5022872/70339144-4676d300-1889-11ea-8f14-293282311531.png">

So I add the ignore. 

Do I make it right? 

```
    'ui_qtext_truncated',
    'ui_qtext_truncated_text',
```

this block, should I add in `ignored_symbols` or `ignored_in_content` ?

After I add the code, I get pretty text. It works nice.

Thank you for the time!


